### PR TITLE
Nuevo validador para cualquier teléfono y validador solo para fijos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
-phpunit.xml
-composer.lock
-composer.phar
-autoload.php
-/vendor/
+/nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+-phpunit.xml
+-composer.lock
+-composer.phar
+-autoload.php
+-/vendor/
 /nbproject/

--- a/Resources/translations/validators.en.yml
+++ b/Resources/translations/validators.en.yml
@@ -1,6 +1,7 @@
 validator.dni.not_valid: DNI incorrect
 validator.phone.not_valid: Phone number incorrect
 validator.phone.mobile.not_valid: Mobilephone number incorrect
+validator.phone.all.not_valid: Phone number incorrect
 validator.zip_code.not_valid: Zip code incorrect
 
 

--- a/Resources/translations/validators.es.yml
+++ b/Resources/translations/validators.es.yml
@@ -1,6 +1,7 @@
 validator.dni.not_valid: DNI no válido
 validator.phone.not_valid: Número de teléfono no válido
 validator.phone.mobile.not_valid: Número de teléfono móvil no válido
+validator.phone.all.not_valid: Número de teléfono no válido
 validator.zip_code.not_valid: Código postal no válido
 
 

--- a/Validator/AllPhone.php
+++ b/Validator/AllPhone.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Xinjia\SpainValidatorBundle\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * Class AllPhone
+ * @package Xinjia\SpainValidatorBundle\Validator
+ * @author Álvaro de la Vega Olmedilla <alvarodlvo@gmail.com>
+ *
+ * @Annotation
+ */
+class AllPhone extends Constraint
+{
+    public $message = 'validator.phone.all.not_valid';
+}

--- a/Validator/AllPhoneValidator.php
+++ b/Validator/AllPhoneValidator.php
@@ -7,11 +7,11 @@ use Symfony\Component\Validator\ConstraintValidator;
 
 
 /**
- * Class PhoneValidator
+ * Class AllPhoneValidator
  * @package Xinjia\SpainValidatorBundle\Validator
  * @author Álvaro de la Vega Olmedilla <alvarodlvo@gmail.com>
  */
-class PhoneValidator extends ConstraintValidator
+class AllPhoneValidator extends ConstraintValidator
 {
     /**
      * @var \Symfony\Component\Validator\Context\ExecutionContextInterface
@@ -50,9 +50,9 @@ class PhoneValidator extends ConstraintValidator
             $return = true;
         }
         
-        if ($telephoneChars[0] == '8' || $telephoneChars[0] == '9')
+        if ($telephoneChars[0] == '6' || $telephoneChars[0] == '7' || $telephoneChars[0] == '8' || $telephoneChars[0] == '9')
         {
-            if (preg_match('/[8-9]\d{8}/', $telephone)) {
+            if (preg_match('/[6-9]\d{8}/', $telephone)) {
                 $return = true;
             }
         }

--- a/Validator/MobilePhoneValidator.php
+++ b/Validator/MobilePhoneValidator.php
@@ -40,16 +40,23 @@ class MobilePhoneValidator extends ConstraintValidator
      * @return bool
      */
     private function checkMobileTelephone($mobileTelephone)
-    {
-        $mobileTelephone = trim($mobileTelephone);
+    {           
+        $return = false;
+        
+        trim($mobileTelephone);
         $telephoneChars = str_split($mobileTelephone);
 
+        if(empty($mobileTelephone)){
+            $return = true;
+        }
+        
         if ($telephoneChars[0] == '6' || $telephoneChars[0] == '7')
         {
-            if (preg_match('/[6-7]\d{8}/', $mobileTelephone))
-                return true;
+            if (preg_match('/[6-7]\d{8}/', $mobileTelephone)) {
+                $return = true;
+            }
         }
 
-        return false;
+        return $return;
     }
 }


### PR DESCRIPTION
He añadido un nuevo validador AllPhoneValidator, que realiza las funciones del antiguo PhoneValidator, y modificado PhoneValidator para que solo valide teléfonos fijos.

Además, he incorporado la opción de que el telefono Móvil no sea obligatorio.
