### PR TITLE
Removed dependency on symfony/validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
     ],
     "require": {
         "php": ">=5.3",
-        "symfony/symfony": ">=2.5",
-        "symfony/validator": "~2.6"
+        "symfony/symfony": ">=2.5"
     },
     "autoload": {
         "psr-0": { "Xinjia\\SpainValidatorBundle": "" }


### PR DESCRIPTION
Removed dependency on symfony/validator, as it is not available on Symfony's 3.1 branch anymore.